### PR TITLE
Add attach & detach

### DIFF
--- a/cyclr.js
+++ b/cyclr.js
@@ -42,13 +42,21 @@ function getRecord(datain) {
 
 // POST function.
 function createRecord(datain) {
-    var record = nlapiCreateRecord(datain.recordtype);
-    return setRecord(record, datain);
+    if (datain.cmd == 'attach') {
+        nlapiAttachRecord(datain.sourceType, datain.sourceId, datain.destinationType, datain.destinationId, datain.options); 
+    } else {
+        var record = nlapiCreateRecord(datain.recordtype);
+        return setRecord(record, datain);
+    }
 }
 
 // DELETE function.
 function deleteRecord(datain) {
-    nlapiDeleteRecord(datain.recordtype, datain.id);
+    if (datain.cmd == 'detach') {
+        nlapiDetachRecord(datain.sourceType, datain.sourceId, datain.destinationType, datain.destinationId, datain.options);
+    } else {
+        nlapiDeleteRecord(datain.recordtype, datain.id);
+    }
 }
 
 // PUT function.


### PR DESCRIPTION
Using update contact to set a company is causing an CONTACT_ALREADY_EXISTS error, this change will allow us to add an Attach and Detach method to the connector, hopefully using attach will resolve the issue.