### PR TITLE
Update createRecord with transform

### DIFF
--- a/cyclr.js
+++ b/cyclr.js
@@ -57,11 +57,18 @@ function getRecord(datain) {
 
 // POST function.
 function createRecord(datain) {
-    if (datain.cmd == 'attach') {
-        nlapiAttachRecord(datain.sourceType, datain.sourceId, datain.destinationType, datain.destinationId, datain.options); 
-    } else {
-        var record = nlapiCreateRecord(datain.recordtype);
-        return setRecord(record, datain);
+    switch (datain.cmd) {
+        case 'attach':
+            nlapiAttachRecord(datain.sourceType, datain.sourceId, datain.destinationType, datain.destinationId, datain.options);
+            break;
+
+        case 'transform':
+            nlapiTransformRecord(datain.sourceType, datain.sourceId, datain.destinationType, datain.options);
+            break;
+
+        default:
+            var record = nlapiCreateRecord(datain.recordtype);
+            return setRecord(record, datain);
     }
 }
 


### PR DESCRIPTION
Updated the createRecord function to support calling nlapiTransformRecord by passing 'transform' as the cmd. https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_N3027360.html#bridgehead_N3032124